### PR TITLE
fix(base_iso3166): add codes of countries according to the code iso 3166

### DIFF
--- a/base_iso3166/models/res_country.py
+++ b/base_iso3166/models/res_country.py
@@ -27,13 +27,23 @@ class ResCountry(models.Model):
     def _compute_codes(self):
         for country in self:
             try:
-                c = pycountry.countries.get(alpha2=country.code)
-                country.code_alpha3 = c.alpha3
+                try:
+                    c = pycountry.countries.get(alpha_2=country.code)
+                except KeyError:
+                    c = pycountry.countries.get(alpha2=country.code)
+                country.code_alpha3 = getattr(c, 'alpha_3',
+                                              getattr(c, 'alpha3', False))
                 country.code_numeric = c.numeric
             except KeyError:
                 try:
-                    c = pycountry.historic_countries.get(alpha2=country.code)
-                    country.code_alpha3 = c.alpha3
+                    try:
+                        c = pycountry.historic_countries.get(
+                            alpha_2=country.code)
+                    except KeyError:
+                        c = pycountry.historic_countries.get(
+                            alpha2=country.code)
+                    country.code_alpha3 = getattr(c, 'alpha_3',
+                                                  getattr(c, 'alpha3', False))
                     country.code_numeric = c.numeric
                 except KeyError:
                     country.code_alpha3 = False


### PR DESCRIPTION
modified res_country.py with the adjustments made for version 10 since it did not recognize the
two-letter code when inserting it for what it returned false. with this adaptation already shows the
codes to three characters according to the standard Iso 3166